### PR TITLE
Add opt-in SeedByHHId to RandSeed: household-keyed draws independent of dataset position (#15)

### DIFF
--- a/EM_Libraries/EM_Common/Definitions/DefPar/RandSeed.cs
+++ b/EM_Libraries/EM_Common/Definitions/DefPar/RandSeed.cs
@@ -5,6 +5,7 @@
         public static class RandSeed
         {
             public const string Seed = "Seed";
+            public const string SeedByHHId = "SeedByHHId";
 
             internal static void Add(DefinitionAdmin.Fun fun)
             {
@@ -12,6 +13,11 @@
                 {
                     valueType = PAR_TYPE.NUMBER,
                     minCount = 0, maxCount = 1, defaultValue = 1
+                });
+                fun.par.Add(SeedByHHId, new DefinitionAdmin.Par()
+                {
+                    valueType = PAR_TYPE.BOOLEAN,
+                    minCount = 0, maxCount = 1, defaultValue = false
                 });
             }
         }

--- a/EM_Libraries/EM_Common/Definitions/DefinitionAdmin_Descriptions.cs
+++ b/EM_Libraries/EM_Common/Definitions/DefinitionAdmin_Descriptions.cs
@@ -148,6 +148,7 @@ namespace EM_Common
             { DefFun.Totals+"|"+DefPar.Totals.Use_Weights, "If set to yes weights are used to calculate the aggregates." },
             { DefFun.Totals+"|"+DefPar.Totals.Weight_Var, "Specifies an alternative weight variable." },
             { DefFun.RandSeed+"|"+DefPar.RandSeed.Seed, "Integer value as starting point for random number generation." },
+            { DefFun.RandSeed+"|"+DefPar.RandSeed.SeedByHHId, "If set to yes each household's random stream is seeded by a deterministic combination of Seed and the household's idhh, so its draws do not depend on the household's position in, or the composition of, the input data (the identical household with the identical idhh draws identically in any run).\nDefault no: household seeds are drawn from one shared sequence in input order." },
             { DefFun.CallProgramme+"|"+DefPar.CallProgramme.Programme, "Name of the application to be called.\nExample: Excel.exe" },
             { DefFun.CallProgramme+"|"+DefPar.CallProgramme.Path, "Path to the application.\nDispensable if the application is  installed at the standard path for programmes.\nHowever, note that the path is also used as the working directory for the application.\nExample: C:\\Program Files\\Microsoft Office\\ \nNote that spaces can be used without encapsulating the path by '." },
             { DefFun.CallProgramme+"|"+DefPar.CallProgramme.Argument, "Programme argument to be passed to the application.\nExample: C:\\EuromodFiles\\Tools\\EMT_FillTemplate.xls (to e.g. open Excel with this workbook)" },

--- a/EM_executable/EM_Executable/Functions/FunRandSeed.cs
+++ b/EM_executable/EM_Executable/Functions/FunRandSeed.cs
@@ -10,6 +10,7 @@ namespace EM_Executable
         internal FunRandSeed(InfoStore infoStore) : base(infoStore) { }
 
         private int seed = 1;
+        private bool seedByHHId = false;
 
         object randLock = new object();     // used for thread-safety
 
@@ -20,6 +21,9 @@ namespace EM_Executable
             ParNumber parSeed = GetUniquePar<ParNumber>(DefPar.RandSeed.Seed);
             seed = parSeed != null ? (int)parSeed.GetValue() :
                 DefinitionAdmin.GetParDefault<int>(DefFun.RandSeed, DefPar.RandSeed.Seed);
+            ParBool parSeedByHHId = GetUniquePar<ParBool>(DefPar.RandSeed.SeedByHHId);
+            seedByHHId = parSeedByHHId != null ? parSeedByHHId.GetBoolValue() :
+                DefinitionAdmin.GetParDefault<bool>(DefFun.RandSeed, DefPar.RandSeed.SeedByHHId);
         }
 
         // RandSeed is the only non-TU based function that runs on HH instead of individuals! 
@@ -37,7 +41,7 @@ namespace EM_Executable
                     if (!hasRun)        // double-check after the lock, just in case...
                     {
                         // if this RandSeed has not run before, then add new seeds for this RandSeed to all HHs
-                        infoStore.hhAdmin.SetSeed(description.funID, seed);
+                        infoStore.hhAdmin.SetSeed(description.funID, seed, seedByHHId);
                         hasRun = true;
                     }
                 }

--- a/EM_executable/EM_Executable/Households/HHAdmin_GetSet.cs
+++ b/EM_executable/EM_Executable/Households/HHAdmin_GetSet.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using EM_Common;
+using System;
 using System.Collections.Generic;
 
 namespace EM_Executable
@@ -32,13 +33,38 @@ namespace EM_Executable
         }
 
         /// <summary>
-        /// This function will accept a seed and calculate new seeds for each HH
+        /// This function will accept a seed and calculate new seeds for each HH.
+        /// By default each HH draws its seed from one shared sequence, i.e. in input order,
+        /// so a household's seed depends on its position in (and the composition of) the data.
+        /// With seedByHHId the seed is instead a deterministic mix of the RandSeed seed and
+        /// the household's idhh: draws become independent of input order, of the presence of
+        /// other households, and of subsetting, while staying reproducible for a given seed.
         /// </summary>
-        internal void SetSeed(string funID, int seed)
+        internal void SetSeed(string funID, int seed, bool seedByHHId = false)
         {
+            if (seedByHHId)
+            {
+                int indexIDHH = infoStore.operandAdmin.GetIndexInPersonVarList(DefVarName.IDHH);
+                foreach (HH hh in hhs)
+                    hh.SetSeed(funID, GetHHIdKeyedSeed(seed, hh.GetPersonValue(indexIDHH, 0)));
+                return;
+            }
             Random random = new Random(seed);
             foreach (HH hh in hhs)
                 hh.SetSeed(funID, random.Next());
+        }
+
+        /// <summary> mix seed and household id into a per-household seed (SplitMix64-style avalanche) </summary>
+        private static int GetHHIdKeyedSeed(int seed, double hhId)
+        {
+            unchecked
+            {
+                ulong z = ((ulong)(uint)seed << 32) ^ (ulong)(long)hhId;
+                z = (z ^ (z >> 30)) * 0xBF58476D1CE4E5B9UL;
+                z = (z ^ (z >> 27)) * 0x94D049BB133111EBUL;
+                z ^= z >> 31;
+                return (int)(z >> 33); // non-negative 31-bit seed for Random
+            }
         }
     }
 }


### PR DESCRIPTION
Implements the opt-in household-keyed random draws proposed in #15.

## Problem

`HHAdmin.SetSeed` derives each household's seed by iterating `hhs` in dataset order with one master `Random(seed)`:

```csharp
Random random = new Random(seed);
foreach (HH hh in hhs)
    hh.SetSeed(funID, random.Next());
```

The household at position *k* always receives the *k*-th `random.Next()`, so any output downstream of a `rand` draw (benefit take-up corrections, random assignment) depends on the household's position in the input file and on which other households are present. Identical households at different positions get different simulated results; adding, removing, or subsetting households reshuffles every subsequent household's draws (evidence across EUROMOD BE_2025 `bed_s` and UKMOD UC/Pension Credit in #15).

## Change

A new optional `RandSeed` parameter **`SeedByHHId`** (boolean, default **no**). When set, each household's seed is a deterministic SplitMix64-style mix of the `Seed` value and the household's `idhh` instead of a draw from the shared positional sequence:

- **composition/subset-invariant** — adding, removing, or filtering households does not change other households' draws;
- **reproducible** — the same household (same `idhh`) with the same `Seed` draws identically in every run;
- **statistically equivalent in aggregate** — per-draw marginals remain uniform, so calibrated take-up shares are preserved in expectation.

The default path is byte-for-byte unchanged: existing models and published results are unaffected unless a model explicitly opts in.

Touched files:

- `EM_Libraries/EM_Common/Definitions/DefPar/RandSeed.cs` — register the parameter (optional boolean, default no)
- `EM_Libraries/EM_Common/Definitions/DefinitionAdmin_Descriptions.cs` — UI description
- `EM_executable/EM_Executable/Functions/FunRandSeed.cs` — read the parameter, pass through
- `EM_executable/EM_Executable/Households/HHAdmin_GetSet.cs` — keyed seed derivation (per-household `Random` objects and everything downstream are unchanged)

## Validation

Run on UKMOD_PUBLIC_B1.02 (a model vintage compatible with this repository's engine source, v3.6.2), country UK16, system UK_2025, dataset `training_data`, with the Benefit Take-up Adjustments extension enabled so the `i_rand_tu` take-up draw executes. Input: ten byte-for-byte identical zero-income single pensioners (distinct `idhh`/`idperson` only, so each is unambiguously entitled to the full Pension Credit guarantee), with `i_rand_tu` added to the standard output so the draw itself is observable. Engine driven through `Control.Run` (sequential run forced).

**Default behaviour (no flag) — draws are positional:**

| run | i_rand_tu per household |
|---|---|
| households 1–10 | 0.71, 0.65, 0.95, 0.75, 0.38, 0.93, 0.95, 0.19, 0.44, 0.67 |
| drop household 1 (2–10 remain) | 0.71, 0.65, 0.95, 0.75, 0.38, 0.93, 0.95, 0.19, 0.44 |

Removing one household shifts every remaining household's draw by exactly one position (`draw'[h] == draw[h−1]` for all h) — identical facts, different results, purely by rank. `boamt_s` lotteries accordingly (957.26 vs 0.0 by position).

**With `SeedByHHId=yes` — draws are household-keyed:**

| run | i_rand_tu per household |
|---|---|
| households 1–10 | 0.29, 0.77, 0.63, 0.34, 0.15, 0.99, 0.82, 0.82, 0.59, 0.47 |
| drop household 1 (2–10 remain) | 0.77, 0.63, 0.34, 0.15, 0.99, 0.82, 0.82, 0.59, 0.47 |
| subset {3, 7} only | 0.63, 0.82 |
| rerun of the full ten | identical |

Every household keeps its own draw under any composition; `boamt_s` follows the take-up rule exactly (paid iff draw ≤ $PCGCSCTU = 0.69; six of ten take up, consistent with the calibrated rate).

Two version-skew observations from setting this up, in case useful: the published source aborts on current model releases (BE_2025's `DefConst` `IsLiteral` parameter is unknown to v3.6.2, and UKMOD B2026.03 hits an unlocated null reference), and the Python connector's `Control.RunFromPython` entry point does not exist in the published source — the repository seems to lag the binaries shipped with the `euromod` package. Happy to file separately if that is useful.

Relates to #15 (proposal and cross-model evidence) and #4 (the dataset-name gating that forces hypothetical-household validation runs onto real dataset-configuration names, where take-up corrections are active).
